### PR TITLE
Update article link to new blog URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Building & Deploying a Gatsby Website to IPFS Using Azure Pipelines
-This repository contains the code disscused in the article [Building & Deploying a Gatsby Website to IPFS Using Azure Pipelines](https://medium.com/cladular/building-deploying-a-gatsby-website-to-ipfs-using-azure-pipelines-7dd095a861fb).
+This repository contains the code disscused in the article [Building & Deploying a Gatsby Website to IPFS Using Azure Pipelines](https://itaypodhajcer.com/blog/building-deploying-a-gatsby-website-to-ipfs-using-azure-pipelines/).


### PR DESCRIPTION
The article for this repository is now published on my personal blog.

This updates the README link from the old story URL to the new canonical URL:

https://itaypodhajcer.com/blog/building-deploying-a-gatsby-website-to-ipfs-using-azure-pipelines/
